### PR TITLE
Remove datasource from Prometheus target spec

### DIFF
--- a/specs/7.0/targets/Prometheus.yml
+++ b/specs/7.0/targets/Prometheus.yml
@@ -3,9 +3,6 @@ Prometheus:
   required:
     - expr
   properties:
-    datasource:
-      type: string
-      default: default
     expr:
       type: string
     format:


### PR DESCRIPTION
Don't think this field is needed. It's a datasource set per panel, not per target? Bugs out my target when viewing it in the UI using the default value:
![image](https://user-images.githubusercontent.com/12065867/101983945-761ba080-3c7e-11eb-8e27-4c0b100f7365.png)
Any targets added through the UI does not have this field. We could set it to null by default as in [the <7.0 grafonlibnet](https://github.com/grafana/grafonnet-lib/blob/master/grafonnet/prometheus.libsonnet#L24). 