### PR TITLE
Extend spec of graph panel to expose fieldConfig

### DIFF
--- a/specs/7.0/panels/Graph.yml
+++ b/specs/7.0/panels/Graph.yml
@@ -220,6 +220,12 @@ defaults:
     custom:
       type: object
       default: {}
+    max:
+      type: integer
+    min:
+      type: integer
+    unit:
+      type: string
 
 fieldConfig:
   type: object


### PR DESCRIPTION
I had quite some trouble making a graph panel use a unit using grafonnet-7.0, as the documentation does not hint at how to do that and trying to do it using ".addYaxis" always resulted in empty graphs. In the stats panel this can be achieved using `setFieldConfig`, but the graph panel does not have this method.

So here is a PR, which extends the graph panel spec, by adding min, max and unit to the fieldConfig defaults, which in turn makes the generated Jsonnet code for the graph panel have a `setFieldConfig` method, which allows globally setting the unit for the graph.

I tested this against my 7.4.2 grafana, and it works and it does, what I need...

I have no idea, if this is even remotely the right thing to do, but I'll take pointers to how to do it, if it is wrong. ;-)
