### PR TITLE
Fixed typo and arrays without types in spec

### DIFF
--- a/specs/7.0/panels/Graph.yml
+++ b/specs/7.0/panels/Graph.yml
@@ -99,6 +99,8 @@ Graph:
           type: string
         timeRegions:
           type: array
+          items:
+            type: object
         timeShift:
           type: string
         tooltip:
@@ -164,6 +166,8 @@ Graph:
               description: Show or hide the axis.
             values:
               type: array
+              items:
+                type: string
               default: []
         yaxes:
           type: array

--- a/specs/7.0/panels/_override.yml
+++ b/specs/7.0/panels/_override.yml
@@ -2,7 +2,7 @@ override:
   type: object
   properties:
     matcher:
-      type: oject
+      type: object
       properties:
         id:
           type: string

--- a/specs/7.0/templates/Custom.yml
+++ b/specs/7.0/templates/Custom.yml
@@ -28,6 +28,8 @@ Custom:
       type: string
     options:
       type: array
+      items:
+        type: object
     query:
       type: string
     queryValue:

--- a/specs/7.0/templates/Datasource.yml
+++ b/specs/7.0/templates/Datasource.yml
@@ -28,6 +28,8 @@ Datasource:
       type: string
     options:
       type: array
+      items:
+        type: object
     query:
       type: string
     refresh:


### PR DESCRIPTION
This PR fixes a couple of issues with generation of spec.json.
1. `oject` -> `object` typo in `specs/7.0/panels/_override.yml`
2. Missing array types (see `Array` in https://swagger.io/docs/specification/data-models/data-types/).

It was tested with swagger-editor v3.16.3