### PR TITLE
Log line number with errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,9 @@ type Language struct {
 }
 
 func main() {
+	// change the flags on the default logger
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
 	args := os.Args[1:]
 	specVersion, language := args[0], args[1]
 	err := generate(


### PR DESCRIPTION
I was seeing:
```console
2022/08/15 11:42:12 open _gen/7.0/spec.json: no such file or directory
exit status 1
```

I now see:
```console
2022/08/15 11:43:35 main.go:44: open _gen/7.0/spec.json: no such file or directory
exit status 1
```